### PR TITLE
Add dynamic risk management

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ python trading_bot_unified.py
 
 On Windows you can also run `start.bat`.
 
+## Dynamic Risk Management
+
+The bot now includes an optional self-adjusting risk mode. When enabled (the
+default), the position size risk percentage increases after a series of winning
+trades and decreases after losses, bounded by the limits defined in
+`RiskSettings`.
+


### PR DESCRIPTION
## Summary
- add dynamic risk adjustment based on recent trade performance
- track current risk percent and win/loss statistics
- update stop-loss logic to use dynamic risk
- document new feature in README

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687aa597f44083328f188eec7e054214