### PR TITLE
Improve error handling for Binance client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ default), the position size risk percentage increases after a series of winning
 trades and decreases after losses, bounded by the limits defined in
 `RiskSettings`.
 
+## Troubleshooting
+
+If the bot exits with a `TimeoutError` during startup, it usually means the
+Binance API could not be reached. Verify that your network connection allows
+outbound HTTPS requests to `api.binance.com` and try again. Some environments may
+require a proxy or VPN to access the API.
+

--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -1653,7 +1653,15 @@ async def _aiohttp_session_provider() -> AsyncGenerator[aiohttp.ClientSession, N
 async def _binance_client_provider(
     config: BotSettings,
 ) -> AsyncGenerator[AsyncClient, None]:
-    client = await AsyncClient.create(config.api.binance_key, config.api.binance_secret)
+    log = structlog.get_logger("BinanceClientProvider")
+    try:
+        client = await AsyncClient.create(
+            config.api.binance_key,
+            config.api.binance_secret,
+        )
+    except Exception as e:
+        log.critical("Failed to initialize Binance client", error=str(e))
+        raise
     try:
         yield client
     finally:


### PR DESCRIPTION
## Summary
- handle Binance initialization errors in the provider
- document possible timeout error in README

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687aac1676208332abe29bc965193a7c