### PR TITLE
Enhance risk handling with trailing stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ default), the position size risk percentage increases after a series of winning
 trades and decreases after losses, bounded by the limits defined in
 `RiskSettings`.
 
+## Trailing Stops
+
+Open positions automatically use a trailing stop that moves up as the price
+increases. The trailing distance is equal to the initial risk amount,
+allowing profits to be locked in while letting winners run.
+
 ## Troubleshooting
 
 If the bot exits with a `TimeoutError` during startup, it usually means the


### PR DESCRIPTION
## Summary
- tweak RiskSettings for moderate defaults
- introduce trailing stop logic in `manage_open_positions`
- exit positions when trailing stop triggers
- document trailing stop feature in README

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687ae13c387483329f59676ba82f91d9