### PR TITLE
Add auto symbol refresh and mid risk defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Open positions automatically use a trailing stop that moves up as the price
 increases. The trailing distance is equal to the initial risk amount,
 allowing profits to be locked in while letting winners run.
 
+## Automatic Symbol Refresh
+
+Every 10 minutes the bot fetches the top trading pairs by volume and
+restarts its market data streams if the list of symbols has changed. This
+keeps the strategy focused on the most liquid markets without manual
+intervention.
+
 ## Troubleshooting
 
 If the bot exits with a `TimeoutError` during startup, it usually means the


### PR DESCRIPTION
## Summary
- lower default risk values
- add `refresh_streams` method to `DataHandler`
- periodically reload top symbols
- document automatic symbol refresh

## Testing
- `python -m py_compile trading_bot_unified.py`


------
https://chatgpt.com/codex/tasks/task_e_687ae3ad186483329365a60438e775a6