### PR TITLE
Implement dynamic JSON config watching

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,73 @@
+{
+  "version": "8.6-Fixed",
+  "log_level": "INFO",
+  "is_production": false,
+  "db_path": "data/trades_v8.db",
+  "correlation_matrix_path": "data/correlation_matrix_v8.pkl",
+  "concurrent_api_calls": 10,
+  "api_timeout_seconds": 15,
+  "api_max_retries": 5,
+  "api_backoff_factor": 1.5,
+  "position_manage_interval_sec": 15,
+  "symbol_refresh_interval_sec": 600,
+  "portfolio_status_interval_sec": 60,
+  "api": {
+    "binance_key": "XuVNCAWYHNAp96fDSgRQG9XMG8szNXxAUo48KgYvZKhByGOqCdEXgfau6cAtemqL",
+    "binance_secret": "EkvnJEeLCAtnuprLhZXVnqc1pVSqm6ZRd4M1n7JrRbbBHzkZGcWaFboporHrkZyZ",
+    "openai_api_key": "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",
+    "discord_webhook_url": "https://discord.com/api/webhooks/912071127902335067/MwEfPPjDpsfn2MGKe7Bdo6hUgtAZ7aqI7NOisjqyaOySeJfi_gbQRf-Q1PQJjwVI8G_X"
+  },
+  "trading": {
+    "quote_asset": "USDC",
+    "interval": "15m",
+    "top_n_symbols": 100,
+    "max_active_positions": 50,
+    "initial_cash_balance": 1000.0,
+    "trading_mode": "PAPER"
+  },
+  "strategy": {
+    "data_fetch_limit": 750,
+    "min_candles_for_analysis": 200,
+    "signal_consensus_threshold": 1,
+    "rsi_period": 14,
+    "rsi_oversold": 30,
+    "rsi_overbought": 70,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "ichimoku_tenkan": 9,
+    "ichimoku_kijun": 26,
+    "ichimoku_senkou_b": 52
+  },
+  "risk": {
+    "initial_risk_per_trade_pct": 0.015,
+    "max_risk_per_trade_pct": 0.025,
+    "min_risk_per_trade_pct": 0.01,
+    "risk_reward_ratio": 2.0,
+    "atr_period_risk": 14,
+    "atr_stop_multiplier": 2.0,
+    "enable_concentration_veto": true,
+    "correlation_threshold": 0.8,
+    "correlation_matrix_update_interval_sec": 3600,
+    "dynamic_risk": true
+  },
+  "ai": {
+    "enable_ai_decider": true,
+    "min_ai_confidence_score": 0.6
+  },
+  "regime": {
+    "enabled": true,
+    "model_path": "data/market_regime_hmm.joblib",
+    "training_ticker": "BTCUSDC",
+    "training_tickers": [
+      "BTCUSDC",
+      "ETHUSDC",
+      "BNBUSDC"
+    ],
+    "hmm_training_days": 2000,
+    "high_risk_regimes": [
+      "Bearish Volatile"
+    ],
+    "retraining_interval_sec": 86400
+  }
+}

--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -11,6 +11,7 @@ import random
 import csv
 import signal
 import time
+import contextlib
 from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 from typing import (
@@ -162,13 +163,46 @@ log = structlog.get_logger("TradingBotV8.5-Final")
 # ==============================================================================
 
 
+class ObservableSettings(BaseSettings):
+    """Base settings class that triggers a callback on any attribute change."""
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        object.__setattr__(self, "_change_callback", None)
+        object.__setattr__(self, "_in_update", False)
+
+    def set_change_callback(self, callback):
+        object.__setattr__(self, "_change_callback", callback)
+        for v in self.__dict__.values():
+            if isinstance(v, ObservableSettings):
+                v.set_change_callback(callback)
+
+    def begin_update(self):
+        object.__setattr__(self, "_in_update", True)
+        for v in self.__dict__.values():
+            if isinstance(v, ObservableSettings):
+                v.begin_update()
+
+    def end_update(self):
+        for v in self.__dict__.values():
+            if isinstance(v, ObservableSettings):
+                v.end_update()
+        object.__setattr__(self, "_in_update", False)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        cb = getattr(self, "_change_callback", None)
+        if cb and not getattr(self, "_in_update", False):
+            cb()
+
+
 class StrategyType(str, Enum):
     TREND_MACD = "TREND_MACD"
     MEAN_REVERSION_RSI = "MEAN_REVERSION_RSI"
     ICHIMOKU_BREAKOUT = "ICHIMOKU_BREAKOUT"
 
 
-class ApiSettings(BaseSettings):
+class ApiSettings(ObservableSettings):
     binance_key: str = "YOUR_BINANCE_API_KEY"
     binance_secret: str = "YOUR_BINANCE_SECRET_KEY"
     openai_api_key: str = "YOUR_OPENAI_API_KEY"
@@ -178,7 +212,7 @@ class ApiSettings(BaseSettings):
     )
 
 
-class TradingSettings(BaseSettings):
+class TradingSettings(ObservableSettings):
     quote_asset: str = "USDC"
     interval: str = "15m"
     top_n_symbols: int = 100
@@ -187,7 +221,7 @@ class TradingSettings(BaseSettings):
     trading_mode: str = "PAPER"  # 'LIVE' or 'PAPER'
 
 
-class StrategySettings(BaseSettings):
+class StrategySettings(ObservableSettings):
     model_config = SettingsConfigDict(env_prefix="STRATEGY_")
     data_fetch_limit: int = 750
     min_candles_for_analysis: int = 200
@@ -203,7 +237,7 @@ class StrategySettings(BaseSettings):
     ichimoku_senkou_b: int = 52
 
 
-class RiskSettings(BaseSettings):
+class RiskSettings(ObservableSettings):
     """Configuration controlling position risk."""
 
     # Base risk used when the bot starts. This will be adjusted dynamically
@@ -227,12 +261,12 @@ class RiskSettings(BaseSettings):
     dynamic_risk: bool = True
 
 
-class AISettings(BaseSettings):
+class AISettings(ObservableSettings):
     enable_ai_decider: bool = True
     min_ai_confidence_score: float = 0.60
 
 
-class RegimeSettings(BaseSettings):
+class RegimeSettings(ObservableSettings):
     """New settings for the Market Regime Detector."""
 
     enabled: bool = True
@@ -248,7 +282,7 @@ class RegimeSettings(BaseSettings):
     retraining_interval_sec: int = 86400  # Retrain every 24 hours
 
 
-class BotSettings(BaseSettings):
+class BotSettings(ObservableSettings):
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
     )
@@ -270,6 +304,80 @@ class BotSettings(BaseSettings):
     risk: RiskSettings = RiskSettings()
     ai: AISettings = AISettings()
     regime: RegimeSettings = RegimeSettings()
+
+
+class ConfigManager:
+    """Loads, watches and persists bot settings from a JSON file."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.log = structlog.get_logger(self.__class__.__name__)
+        self.config = self._load_or_create()
+        self.config.set_change_callback(self.save)
+        self.last_mtime = self.path.stat().st_mtime if self.path.exists() else 0
+        self._watch_task: Optional[asyncio.Task] = None
+
+    def _load_or_create(self) -> BotSettings:
+        if self.path.exists():
+            try:
+                with self.path.open() as f:
+                    data = json.load(f)
+                return BotSettings.model_validate(data)
+            except Exception as e:
+                self.log.error("Failed to load config.json, using defaults", error=e)
+        cfg = BotSettings()
+        self.save(cfg)
+        return cfg
+
+    def save(self, *_):
+        try:
+            with self.path.open("w") as f:
+                json.dump(self.config.model_dump(), f, indent=2)
+            self.last_mtime = self.path.stat().st_mtime
+        except Exception as e:
+            self.log.error("Failed to write config.json", error=e)
+
+    async def _watch_loop(self, interval: int = 1):
+        while not SHUTDOWN_EVENT.is_set():
+            try:
+                if self.path.exists():
+                    mtime = self.path.stat().st_mtime
+                    if mtime != self.last_mtime:
+                        self.log.info("Reloading configuration from file")
+                        with self.path.open() as f:
+                            data = json.load(f)
+                        new_cfg = BotSettings.model_validate(data)
+                        self.config.begin_update()
+                        try:
+                            self._apply_updates(self.config, new_cfg)
+                        finally:
+                            self.config.end_update()
+                        self.last_mtime = mtime
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self.log.error("Error watching config file", error=e)
+
+    def _apply_updates(self, current: ObservableSettings, new: ObservableSettings):
+        for name in current.model_fields:
+            cur_val = getattr(current, name)
+            new_val = getattr(new, name)
+            if isinstance(cur_val, ObservableSettings):
+                self._apply_updates(cur_val, new_val)
+            else:
+                if cur_val != new_val:
+                    setattr(current, name, new_val)
+
+    def start_watch(self, interval: int = 1):
+        if self._watch_task is None:
+            self._watch_task = asyncio.create_task(self._watch_loop(interval))
+
+    async def stop_watch(self):
+        if self._watch_task:
+            self._watch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._watch_task
 
 
 # --- Event-Driven Architecture (EDA) Core Components ---
@@ -1703,7 +1811,8 @@ async def _binance_client_provider(
 
 
 class AppContainer(containers.DeclarativeContainer):
-    config = providers.Singleton(BotSettings)
+    config_manager = providers.Singleton(ConfigManager, Path("config.json"))
+    config = providers.Singleton(lambda cm: cm.config, config_manager)
     aiohttp_session = providers.Resource(_aiohttp_session_provider)
     binance_client = providers.Resource(_binance_client_provider, config=config)
     exchange = providers.Singleton(
@@ -1863,6 +1972,7 @@ async def refresh_symbol_list(
 @inject
 async def start_bot(
     config: BotSettings = Provide[AppContainer.config],
+    config_manager: ConfigManager = Provide[AppContainer.config_manager],
     exchange: ExchangeService = Provide[AppContainer.exchange],
     persistence: PersistenceService = Provide[AppContainer.persistence],
     portfolio_manager: PortfolioManager = Provide[AppContainer.portfolio_manager],
@@ -1878,7 +1988,7 @@ async def start_bot(
     def handle_signal(sig):
         log.warning(f"Received signal {sig}. Initiating graceful shutdown.")
         if not SHUTDOWN_EVENT.is_set():
-            asyncio.create_task(graceful_shutdown(loop, notifier))
+            asyncio.create_task(graceful_shutdown(loop, notifier, config_manager))
 
     if sys.platform != "win32":
         for sig in (signal.SIGINT, signal.SIGTERM):
@@ -1886,6 +1996,7 @@ async def start_bot(
 
     try:
         log.info("🚀 LAUNCHING BOT SERVICES")
+        config_manager.start_watch()
         await exchange.initialize()
         await persistence.initialize()
         # Initialize regime detector after exchange service is ready
@@ -1972,10 +2083,14 @@ async def start_bot(
         )
     finally:
         if not SHUTDOWN_EVENT.is_set():
-            await graceful_shutdown(loop, notifier)
+            await graceful_shutdown(loop, notifier, config_manager)
 
 
-async def graceful_shutdown(loop: asyncio.AbstractEventLoop, notifier: Notifier):
+async def graceful_shutdown(
+    loop: asyncio.AbstractEventLoop,
+    notifier: Notifier,
+    config_manager: ConfigManager,
+):
     if SHUTDOWN_EVENT.is_set():
         return
     log.warning(
@@ -1992,6 +2107,7 @@ async def graceful_shutdown(loop: asyncio.AbstractEventLoop, notifier: Notifier)
         task.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
 
+    await config_manager.stop_watch()
     await container.shutdown_resources()
     log.info(f"{Fore.GREEN}✅ Shutdown complete.")
 
@@ -1999,7 +2115,8 @@ async def graceful_shutdown(loop: asyncio.AbstractEventLoop, notifier: Notifier)
 if __name__ == "__main__":
     container = AppContainer()
     try:
-        cfg = container.config()
+        cfg_manager = container.config_manager()
+        cfg = cfg_manager.config
         container.wire(modules=[__name__])
     except Exception as e:
         # V případě chyby v konfiguraci je logging ještě nenastavený, použijeme print


### PR DESCRIPTION
## Summary
- implement `ObservableSettings` and `ConfigManager`
- watch `config.json` for changes and automatically reload
- persist config changes on the fly
- start and stop config watch with the bot
- include default `config.json`

## Testing
- `python -m py_compile trading_bot_unified.py`


------
https://chatgpt.com/codex/tasks/task_e_687b8a60ad148332bf7ebcc696c45447