### PR TITLE
Fix saving default config on invalid JSON

### DIFF
--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -327,7 +327,14 @@ class ConfigManager:
             except Exception as e:
                 self.log.error("Failed to load config.json, using defaults", error=e)
         cfg = BotSettings()
-        self.save(cfg)
+        try:
+            data = cfg.model_dump()
+            data.pop("api", None)
+            with self.path.open("w") as f:
+                json.dump(data, f, indent=2)
+            self.last_mtime = self.path.stat().st_mtime
+        except Exception as e:
+            self.log.error("Failed to write default config.json", error=e)
         return cfg
 
     def save(self, *_):


### PR DESCRIPTION
## Summary
- ensure ConfigManager writes a default config when loading fails
- avoid AttributeError during initialization when config.json is invalid

## Testing
- `python3 -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9a4c736c833281cbec63bad1e46b