### PR TITLE
Fix config serialization to JSON

### DIFF
--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -328,7 +328,8 @@ class ConfigManager:
                 self.log.error("Failed to load config.json, using defaults", error=e)
         cfg = BotSettings()
         try:
-            data = cfg.model_dump()
+            # Use JSON mode so Path objects are converted to strings
+            data = cfg.model_dump(mode="json")
             data.pop("api", None)
             with self.path.open("w") as f:
                 json.dump(data, f, indent=2)
@@ -339,7 +340,8 @@ class ConfigManager:
 
     def save(self, *_):
         try:
-            data = self.config.model_dump()
+            # Use JSON mode so Path objects are converted to strings
+            data = self.config.model_dump(mode="json")
             data.pop("api", None)
             with self.path.open("w") as f:
                 json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary
- ensure ConfigManager converts Path objects to JSON-serializable strings

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba5733a9c8332ad2242f88b959595