### PR TITLE
Make uvloop optional for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ pip install -r requirements.txt
 ```
 
 For optimal performance the bot uses `uvloop` as the event loop when available.
+`uvloop` does not currently support Windows, so the bot falls back to the default
+asyncio event loop on that platform.
 
 ## Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ dependency-injector
 colorama
 aiohttp
 joblib
-uvloop
+uvloop; sys_platform != "win32"
 

--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -1,6 +1,5 @@
 # --- Standard & Third-Party Library Imports ---
 import asyncio
-import uvloop
 import json
 import logging
 import math
@@ -69,8 +68,13 @@ from colorama import Fore, Style, init
 # Initialize Colorama for colored console output
 init(autoreset=True)
 
-# Use uvloop for improved asyncio performance
-uvloop.install()
+# Use uvloop for improved asyncio performance when available
+if sys.platform != "win32":
+    try:
+        import uvloop
+        uvloop.install()
+    except ImportError:
+        pass
 
 
 class SafeFileHandler(logging.FileHandler):


### PR DESCRIPTION
## Summary
- skip `uvloop` on Windows so the bot can run on that platform
- only install `uvloop` when available
- make `uvloop` an optional dependency
- document the Windows fallback

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687ecc5ffce48332a85d5ba208ec9a3a