### PR TITLE
Add API rate limiting

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,8 @@
   "api_timeout_seconds": 15,
   "api_max_retries": 5,
   "api_backoff_factor": 1.5,
+  "api_requests_per_second": 18,
+  "order_requests_per_second": 9,
   "position_manage_interval_sec": 15,
   "symbol_refresh_interval_sec": 600,
   "portfolio_status_interval_sec": 60,


### PR DESCRIPTION
## Summary
- set API and order request limits in config and BotSettings
- implement AsyncRateLimiter
- throttle Binance API calls and order placements

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687eceb331308332be94645e90de8f45