### PR TITLE
Fix indicator cache update with insufficient data

### DIFF
--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -1473,6 +1473,8 @@ class StrategyHandler:
             return cached if cached is not None else pl.DataFrame()
 
         new_ind = self._calculate_all_indicators(new_df)
+        if new_ind.is_empty() or new_ind.width == 0:
+            return cached if cached is not None else pl.DataFrame()
         if cached is not None and not cached.is_empty():
             result = (
                 pl.concat([cached, new_ind])


### PR DESCRIPTION
## Summary
- guard against empty indicator DataFrame when updating cache

## Testing
- `python3 -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687edf442ff08332bb5a48806c68cfd4