### PR TITLE
Fix exchange initialization shutdown

### DIFF
--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -841,7 +841,7 @@ class ExchangeService:
                 exc_info=True,
             )
             await self._client.close_connection()
-            sys.exit(1)
+            raise
 
     async def _execute_api_call(self, api_func: Coroutine, *args, **kwargs) -> Any:
         retries = self._config.api_max_retries
@@ -2145,6 +2145,7 @@ async def start_bot(
 ):
     print_banner(config)
     loop = asyncio.get_running_loop()
+    await container.init_resources()
 
     def handle_signal(sig):
         log.warning(f"Received signal {sig}. Initiating graceful shutdown.")


### PR DESCRIPTION
## Summary
- avoid exiting in ExchangeService.initialize
- reinitialize DI container resources when the bot starts

## Testing
- `python -m py_compile trading_bot_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_687fadada4688332bd8ba8c2ef9886ba