### PR TITLE
Restore env placeholders and fix startup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+BINANCE_KEY="your_binance_key"
+BINANCE_SECRET="your_binance_secret"
+OPENAI_API_KEY="your_openai_key"
+DISCORD_WEBHOOK_URL="your_discord_webhook"

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ venv.bak/
 
 # User-specific files
 config_local.py
+!/.env

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the source code for a sophisticated, multi-signal crypt
 
 ## Architecture Overview
 The bot's architecture is modular, separating concerns into distinct packages:
-* **config.py**: Central configuration for API keys, trading pairs, and strategy parameters. You must add your API keys here.
+* **config.py**: Central configuration for trading parameters. API keys are loaded from the `.env` file.
 * **main.py**: The main application entry point that runs the trading loop.
 * **data_ingestion/**: Handles all data collection and feature generation.
   * `binance_client.py`: Manages the connection to the Binance API.
@@ -40,12 +40,12 @@ The bot's architecture is modular, separating concerns into distinct packages:
      * Binance: Go to the [Binance Spot Testnet](https://testnet.binance.vision/) to create free testnet API keys.
      * Glassnode: Sign up for a Glassnode account to get an API key for on-chain data.
      * NewsAPI: Sign up at [newsapi.org](https://newsapi.org) for a free developer API key.
-   * **Edit `config.py`**:
-     * Enter your API keys in the respective sections.
-     * Adjust trading parameters like `TRADE_SYMBOL` and `TIMEFRAME` as needed.
+   * **Create `.env`**:
+     * Copy `.env.sample` to `.env` and fill in your API keys.
+     * Adjust trading parameters like `TRADE_SYMBOL` and `TIMEFRAME` in `config.py` if needed.
 
 ## How to Run
-Ensure your virtual environment is activated and you have configured `config.py`.
+Ensure your virtual environment is activated and you have populated `.env` with your credentials.
 You can run the modular version or the all-in-one script:
 ```bash
 # Modular approach

--- a/config.py
+++ b/config.py
@@ -2,12 +2,17 @@
 
 # --- API Configuration ---
 # IMPORTANT: Use the TESTNET for development and testing.
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
 API_CONFIG = {
     "use_testnet": True,
-    "binance_api_key": "YOUR_BINANCE_TESTNET_API_KEY",
-    "binance_api_secret": "YOUR_BINANCE_TESTNET_API_SECRET",
-    "glassnode_api_key": "YOUR_GLASSNODE_API_KEY",
-    "news_api_key": "YOUR_NEWSAPI_ORG_KEY"
+    "binance_api_key": os.getenv("BINANCE_KEY", "your_binance_key"),
+    "binance_api_secret": os.getenv("BINANCE_SECRET", "your_binance_secret"),
+    "glassnode_api_key": os.getenv("GLASSNODE_API_KEY", "your_glassnode_api_key"),
+    "news_api_key": os.getenv("NEWS_API_KEY", "your_newsapi_org_key"),
 }
 
 # --- Trading Parameters ---

--- a/data_ingestion/binance_client.py
+++ b/data_ingestion/binance_client.py
@@ -14,8 +14,8 @@ class BinanceHandler:
         self.api_key = API_CONFIG["binance_api_key"]
         self.api_secret = API_CONFIG["binance_api_secret"]
 
-        if not self.api_key or "YOUR" in self.api_key:
-            raise ValueError("Binance API key is not set in config.py")
+        if not self.api_key or "your" in self.api_key.lower():
+            raise ValueError("Binance API key is not set in environment")
 
         try:
             self.client = Client(self.api_key, self.api_secret, testnet=self.use_testnet)

--- a/data_ingestion/external_apis.py
+++ b/data_ingestion/external_apis.py
@@ -15,7 +15,7 @@ class ExternalAPIs:
 
     def get_on_chain_data(self, asset):
         """Fetch key on-chain metrics from Glassnode."""
-        if not self.glassnode_api_key or "YOUR" in self.glassnode_api_key:
+        if not self.glassnode_api_key or "your" in self.glassnode_api_key.lower():
             logging.warning("⚠️ Glassnode API key not set. Returning neutral on-chain data.")
             return {'mvrv_z_score': 0, 'sopr': 1.0, 'nupl': 0.5}
 
@@ -45,7 +45,7 @@ class ExternalAPIs:
 
     def get_news_headlines(self, query):
         """Fetch recent news headlines for a given query from NewsAPI."""
-        if not self.news_api_key or "YOUR" in self.news_api_key:
+        if not self.news_api_key or "your" in self.news_api_key.lower():
             logging.warning("⚠️ NewsAPI key not set. Skipping sentiment analysis.")
             return []
 

--- a/execution/trade_executor.py
+++ b/execution/trade_executor.py
@@ -1,7 +1,7 @@
 import logging
 from binance.enums import *
 
-from .position_sizer import PositionSizer
+from risk_management.position_sizer import PositionSizer
 
 
 class TradeExecutor:

--- a/gemini_single.py
+++ b/gemini_single.py
@@ -4,6 +4,7 @@ This file bundles all core functionality in a single script.
 
 import logging
 import time
+import os
 import pandas as pd
 import pandas_ta as ta
 import numpy as np
@@ -13,13 +14,16 @@ from binance.exceptions import BinanceAPIException, BinanceOrderException
 from transformers import pipeline
 from statsmodels.tsa.arima.model import ARIMA
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 API_CONFIG = {
     "use_testnet": True,
-    "binance_api_key": "YOUR_BINANCE_TESTNET_API_KEY",
-    "binance_api_secret": "YOUR_BINANCE_TESTNET_API_SECRET",
-    "glassnode_api_key": "YOUR_GLASSNODE_API_KEY",
-    "news_api_key": "YOUR_NEWSAPI_ORG_KEY",
+    "binance_api_key": os.getenv("BINANCE_KEY", "your_binance_key"),
+    "binance_api_secret": os.getenv("BINANCE_SECRET", "your_binance_secret"),
+    "glassnode_api_key": os.getenv("GLASSNODE_API_KEY", "your_glassnode_api_key"),
+    "news_api_key": os.getenv("NEWS_API_KEY", "your_newsapi_org_key"),
 }
 
 TRADING_CONFIG = {
@@ -134,7 +138,7 @@ class ExternalAPIs:
         self.news_base_url = "https://newsapi.org/v2/everything"
 
     def get_on_chain_data(self, asset):
-        if not self.glassnode_api_key or "YOUR" in self.glassnode_api_key:
+        if not self.glassnode_api_key or "your" in self.glassnode_api_key.lower():
             logging.warning("⚠️ Glassnode API key not set. Returning neutral on-chain data.")
             return {"mvrv_z_score": 0, "sopr": 1.0, "nupl": 0.5}
         metrics = {
@@ -157,7 +161,7 @@ class ExternalAPIs:
         return result
 
     def get_news_headlines(self, query):
-        if not self.news_api_key or "YOUR" in self.news_api_key:
+        if not self.news_api_key or "your" in self.news_api_key.lower():
             logging.warning("⚠️ NewsAPI key not set. Skipping sentiment analysis.")
             return []
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 python-binance
 pandas
-numpy
+numpy<2
 pandas-ta
 requests
 statsmodels
 transformers
 torch
 scikit-learn
+python-dotenv

--- a/trading_bot_unified.py
+++ b/trading_bot_unified.py
@@ -214,10 +214,10 @@ class StrategyType(str, Enum):
 
 
 class ApiSettings(ObservableSettings):
-    binance_key: str = "YOUR_BINANCE_API_KEY"
-    binance_secret: str = "YOUR_BINANCE_SECRET_KEY"
-    openai_api_key: str = "YOUR_OPENAI_API_KEY"
-    discord_webhook_url: str = "YOUR_DISCORD_WEBHOOK_URL"
+    binance_key: str = "your_binance_key"
+    binance_secret: str = "your_binance_secret"
+    openai_api_key: str = "your_openai_key"
+    discord_webhook_url: str = "your_discord_webhook"
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False
     )
@@ -763,7 +763,7 @@ class Notifier:
     async def send(
         self, title: str, msg: str, color: int = 3447003, is_error: bool = False
     ):
-        if not self._webhook_url or "YOUR_DISCORD_WEBHOOK_URL" in self._webhook_url:
+        if not self._webhook_url or "your" in self._webhook_url.lower():
             return
         if self._session.closed:
             self._log.error(
@@ -1112,7 +1112,7 @@ class AIAnalysisManager:
         self.config = config
         if (
             not api_settings.openai_api_key
-            or "YOUR_OPENAI_API_KEY" in api_settings.openai_api_key
+            or "your" in api_settings.openai_api_key.lower()
         ):
             log.warning("OpenAI API key not configured. AI Decider disabled.")
             self.llm_client = None
@@ -2294,8 +2294,8 @@ if __name__ == "__main__":
     )  # Získání loggeru po nastavení
 
     if (
-        "YOUR_BINANCE_API_KEY" in cfg.api.binance_key
-        or "YOUR_BINANCE_SECRET_KEY" in cfg.api.binance_secret
+        "your" in cfg.api.binance_key.lower()
+        or "your" in cfg.api.binance_secret.lower()
     ):
         log.critical(
             "FATAL: API keys are set to placeholders. Please configure them in your .env file before running."


### PR DESCRIPTION
## Summary
- load `.env` and use standardized placeholder names
- update checks for unset API keys
- adjust README to document using `.env`
- add `python-dotenv` and pin `numpy<2`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails due to placeholder API key)*

------
https://chatgpt.com/codex/tasks/task_e_688ca2a0587c8332832086f68e02c065