### PR TITLE
Fix transformers import and pin numpy

### DIFF
--- a/data_ingestion/feature_generator.py
+++ b/data_ingestion/feature_generator.py
@@ -1,8 +1,10 @@
 """Generate TA, on-chain, sentiment and forecast features."""
 import logging
+import os
 import pandas as pd
 import pandas_ta as ta
 import numpy as np
+os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
 from transformers import pipeline
 from statsmodels.tsa.arima.model import ARIMA
 from .external_apis import ExternalAPIs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-binance
 pandas
-numpy
+numpy<2
 pandas-ta
 requests
 statsmodels


### PR DESCRIPTION
## Summary
- disable TensorFlow when importing `transformers`
- restrict numpy to <2 in requirements

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d3486bd188332a4918683aa5caee7