### PR TITLE
Swap Glassnode API for CoinMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The bot's architecture is modular, separating concerns into distinct packages:
 * **main.py**: The main application entry point that runs the trading loop.
 * **data_ingestion/**: Handles all data collection and feature generation.
   * `binance_client.py`: Manages the connection to the Binance API.
-  * `external_apis.py`: Connects to third-party APIs for on-chain data (Glassnode) and news/sentiment (NewsAPI).
+  * `external_apis.py`: Connects to third-party APIs for on-chain data (CoinMetrics) and news/sentiment (NewsAPI).
   * `feature_generator.py`: Calculates technical indicators, fetches external data, and runs a predictive ARIMA model to create a comprehensive feature set.
 * **modeling/**: Responsible for generating the final trading signal.
   * `signal_combiner.py`: Aggregates all features using a weighted scoring system to produce a final Buy/Sell/Hold signal.
@@ -37,12 +37,12 @@ The bot's architecture is modular, separating concerns into distinct packages:
    ```
 3. **Configure the Bot**
    * **Get API Keys**:
-     * Binance: Go to the [Binance Spot Testnet](https://testnet.binance.vision/) to create free testnet API keys.
-     * Glassnode: Sign up for a Glassnode account to get an API key for on-chain data.
-     * NewsAPI: Sign up at [newsapi.org](https://newsapi.org) for a free developer API key.
+    * Binance: Go to the [Binance Spot Testnet](https://testnet.binance.vision/) to create free testnet API keys.
+    * CoinMetrics: This project uses the free [CoinMetrics Community API](https://coinmetrics.io/community-api/), which works without an API key. If you have a key, set `COINMETRICS_API_KEY`.
+    * NewsAPI: Sign up at [newsapi.org](https://newsapi.org) for a free developer API key.
   * **Edit `config.py`**:
     * API keys can be supplied via environment variables (`BINANCE_KEY`,
-      `BINANCE_SECRET`, `GLASSNODE_API_KEY`, `NEWS_API_KEY`). You can place these
+      `BINANCE_SECRET`, `COINMETRICS_API_KEY`, `NEWS_API_KEY`). You can place these
       variables in a `.env` file at the project root and they will be loaded
       automatically.
     * Alternatively you may edit the values directly in the file.

--- a/config.py
+++ b/config.py
@@ -13,7 +13,9 @@ API_CONFIG = {
     "use_testnet": True,
     "binance_api_key": os.environ.get("BINANCE_KEY", "YOUR_BINANCE_TESTNET_API_KEY"),
     "binance_api_secret": os.environ.get("BINANCE_SECRET", "YOUR_BINANCE_TESTNET_API_SECRET"),
-    "glassnode_api_key": os.environ.get("GLASSNODE_API_KEY", "YOUR_GLASSNODE_API_KEY"),
+    # CoinMetrics Community API does not strictly require an API key, but you may
+    # provide one via the COINMETRICS_API_KEY environment variable if you have it.
+    "coinmetrics_api_key": os.environ.get("COINMETRICS_API_KEY", ""),
     "news_api_key": os.environ.get("NEWS_API_KEY", "YOUR_NEWSAPI_ORG_KEY"),
 }
 

--- a/data_ingestion/external_apis.py
+++ b/data_ingestion/external_apis.py
@@ -1,43 +1,49 @@
-"""Wrapper for third-party APIs such as Glassnode and NewsAPI."""
+"""Wrapper for third-party APIs such as CoinMetrics and NewsAPI."""
 import requests
 import logging
 from datetime import datetime, timedelta
 from config import API_CONFIG
 
 class ExternalAPIs:
-    """Handles connections to third-party APIs like Glassnode and NewsAPI."""
+    """Handles connections to third-party APIs like CoinMetrics and NewsAPI."""
 
     def __init__(self):
-        self.glassnode_api_key = API_CONFIG["glassnode_api_key"]
+        self.coinmetrics_api_key = API_CONFIG["coinmetrics_api_key"]
         self.news_api_key = API_CONFIG["news_api_key"]
-        self.glassnode_base_url = "https://api.glassnode.com/v1/metrics"
+        self.coinmetrics_base_url = "https://community-api.coinmetrics.io/v4"
         self.news_base_url = "https://newsapi.org/v2/everything"
 
     def get_on_chain_data(self, asset: str):
-        """Fetch key on-chain metrics from Glassnode."""
-        if not self.glassnode_api_key or "YOUR" in self.glassnode_api_key:
-            logging.warning("⚠️ Glassnode API key not set. Returning neutral on-chain data.")
-            return {"mvrv_z_score": 0, "sopr": 1.0, "nupl": 0.5}
-
-        metrics = {
-            "mvrv_z_score": "/market/mvrv_z_score",
-            "sopr": "/indicators/sopr",
-            "nupl": "/indicators/net_unrealized_profit_loss",
+        """Fetch key on-chain metrics from the CoinMetrics Community API."""
+        metrics_map = {
+            "active_addresses": "AdrActCnt",
+            "transaction_count": "TxTfrCnt",
         }
-        on_chain_features = {}
-        for name, endpoint in metrics.items():
-            try:
-                params = {"a": asset, "api_key": self.glassnode_api_key, "l": 1}
-                response = requests.get(f"{self.glassnode_base_url}{endpoint}", params=params)
-                response.raise_for_status()
-                data = response.json()
-                if data:
-                    on_chain_features[name] = data[-1]["v"]
-                else:
-                    on_chain_features[name] = 0
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Error fetching {name} from Glassnode: {e}")
-                on_chain_features[name] = 0 if name == "mvrv_z_score" else (1.0 if name == "sopr" else 0.5)
+
+        params = {
+            "assets": asset.lower(),
+            "metrics": ",".join(metrics_map.values()),
+            "frequency": "1d",
+            "page_size": 1,
+        }
+
+        if self.coinmetrics_api_key:
+            params["api_key"] = self.coinmetrics_api_key
+
+        try:
+            response = requests.get(
+                f"{self.coinmetrics_base_url}/timeseries/asset-metrics", params=params
+            )
+            response.raise_for_status()
+            data = response.json().get("data", [])
+            latest = data[-1] if data else {}
+            on_chain_features = {
+                name: float(latest.get(metric, 0)) for name, metric in metrics_map.items()
+            }
+        except requests.exceptions.RequestException as e:
+            logging.error(f"❌ Error fetching on-chain data from CoinMetrics: {e}")
+            on_chain_features = {"active_addresses": 0, "transaction_count": 0}
+
         logging.info(f"🔗 Fetched on-chain data: {on_chain_features}")
         return on_chain_features
 

--- a/modeling/signal_combiner.py
+++ b/modeling/signal_combiner.py
@@ -28,14 +28,16 @@ class SignalCombiner:
 
     def _get_on_chain_signal(self):
         score = 0
-        mvrv_z = self.data['mvrv_z_score']
-        sopr = self.data['sopr']
-        if mvrv_z > 7.0:
-            score -= 1
-        elif mvrv_z < 0.1:
-            score += 1
-        if sopr < 1.0:
+        active_addresses = self.data['active_addresses']
+        tx_count = self.data['transaction_count']
+        if active_addresses > 700000:
             score += 0.5
+        elif active_addresses < 300000:
+            score -= 0.5
+        if tx_count > 1000000:
+            score += 0.5
+        elif tx_count < 500000:
+            score -= 0.5
         return max(min(score, 1), -1)
 
     def _get_sentiment_signal(self):


### PR DESCRIPTION
## Summary
- use CoinMetrics Community API for on-chain data
- adjust `signal_combiner` to use new metrics
- document new setup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d3a158f80833285d9745629c4e83b