### PR TITLE
Fix ARIMA forecast column assignment

### DIFF
--- a/data_ingestion/feature_generator.py
+++ b/data_ingestion/feature_generator.py
@@ -60,8 +60,9 @@ class FeatureGenerator:
             model = ARIMA(close_prices, order=(5, 1, 0))
             model_fit = model.fit()
             forecast = model_fit.forecast(steps=1)
-            self.df["arima_forecast"] = forecast
-            logging.info(f"🧠 ARIMA forecast for next period: {float(forecast):.2f}")
+            forecast_value = float(forecast[0])
+            self.df["arima_forecast"] = forecast_value
+            logging.info(f"🧠 ARIMA forecast for next period: {forecast_value:.2f}")
         except Exception as e:
             logging.error(f"❌ ARIMA model failed: {e}. Using last close price as forecast.")
             self.df["arima_forecast"] = close_prices[-1]

--- a/mega_trading_bot.py
+++ b/mega_trading_bot.py
@@ -167,7 +167,9 @@ class FeatureGenerator:
             model = ARIMA(self.df["Close"].values, order=(5, 1, 0))
             fit = model.fit()
             forecast = fit.forecast(steps=1)
-            self.df["arima_forecast"] = forecast
+            forecast_value = float(forecast[0])
+            self.df["arima_forecast"] = forecast_value
+            logging.info(f"ARIMA forecast for next period: {forecast_value:.2f}")
         except Exception as e:
             logging.error(f"ARIMA failed: {e}; using last close")
             self.df["arima_forecast"] = self.df["Close"].iloc[-1]


### PR DESCRIPTION
## Summary
- handle ARIMA forecast as scalar when adding feature
- log the forecast for visibility

## Testing
- `python -m py_compile mega_trading_bot.py data_ingestion/feature_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_688d428cdf6c83329aa231c41bf3a826