### PR TITLE
Fix ARIMA forecast assignment

### DIFF
--- a/data_ingestion/feature_generator.py
+++ b/data_ingestion/feature_generator.py
@@ -59,12 +59,16 @@ class FeatureGenerator:
         try:
             model = ARIMA(close_prices, order=(5, 1, 0))
             model_fit = model.fit()
-            forecast = model_fit.forecast(steps=1)
-            self.df["arima_forecast"] = forecast
-            logging.info(f"🧠 ARIMA forecast for next period: {float(forecast):.2f}")
+            forecast = float(model_fit.forecast(steps=1))
+            self.df["arima_forecast"] = np.nan
+            self.df.loc[self.df.index[-1], "arima_forecast"] = forecast
+            logging.info(f"🧠 ARIMA forecast for next period: {forecast:.2f}")
         except Exception as e:
-            logging.error(f"❌ ARIMA model failed: {e}. Using last close price as forecast.")
-            self.df["arima_forecast"] = close_prices[-1]
+            logging.error(
+                f"❌ ARIMA model failed: {e}. Using last close price as forecast."
+            )
+            self.df["arima_forecast"] = np.nan
+            self.df.loc[self.df.index[-1], "arima_forecast"] = close_prices[-1]
         return self
 
     def generate_features(self):

--- a/mega_trading_bot.py
+++ b/mega_trading_bot.py
@@ -166,11 +166,13 @@ class FeatureGenerator:
         try:
             model = ARIMA(self.df["Close"].values, order=(5, 1, 0))
             fit = model.fit()
-            forecast = fit.forecast(steps=1)
-            self.df["arima_forecast"] = forecast
+            forecast = float(fit.forecast(steps=1))
+            self.df["arima_forecast"] = np.nan
+            self.df.loc[self.df.index[-1], "arima_forecast"] = forecast
         except Exception as e:
             logging.error(f"ARIMA failed: {e}; using last close")
-            self.df["arima_forecast"] = self.df["Close"].iloc[-1]
+            self.df["arima_forecast"] = np.nan
+            self.df.loc[self.df.index[-1], "arima_forecast"] = self.df["Close"].iloc[-1]
         return self
 
     def generate(self) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- prevent shape mismatch error from ARIMA forecast
- store forecast only in the last row of the feature DataFrame

## Testing
- `pip install -r requirements.txt | tail -n 20`
- `python -m py_compile $(git ls-files '*.py') && echo 'python compile OK'`
- `flake8 || echo 'flake8 not installed'`


------
https://chatgpt.com/codex/tasks/task_e_688d428cdf6c83329aa231c41bf3a826