### PR TITLE
Create learning model directory

### DIFF
--- a/learning_model/.gitkeep
+++ b/learning_model/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep the learning model directory tracked by git

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ import signal
 import logging
 import threading
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -82,6 +83,10 @@ def env_level(name: str, default="INFO") -> int:
 
 # ---------------------- load env ----------------------
 load_dotenv()
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODEL_DIR = SCRIPT_DIR / "learning_model"
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
 API_KEY = env_str("BINANCE_API_KEY", "")
 API_SECRET = env_str("BINANCE_API_SECRET", "")
 BASE_URL_OVERRIDE = env_str("BINANCE_BASE_URL", "")

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -3,6 +3,7 @@ import os
 import sys
 import types
 import unittest
+from pathlib import Path
 from typing import List
 from unittest import mock
 
@@ -309,6 +310,13 @@ class TrendMLTests(unittest.TestCase):
         expected_rows = dataset_a[0].shape[0] + dataset_b[0].shape[0]
         trained_rows = second_model.trained[0].shape[0]
         self.assertEqual(trained_rows, expected_rows)
+
+
+class ModelDirectoryTests(unittest.TestCase):
+    def test_learning_model_directory_created_alongside_script(self):
+        expected_dir = Path(MAIN.__file__).resolve().parent / "learning_model"
+        self.assertEqual(MAIN.MODEL_DIR, expected_dir)
+        self.assertTrue(expected_dir.is_dir())
 
 
 class EntrySignalIntegrationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- create a dedicated `learning_model` directory beside the trading bot script for storing ML artifacts
- expose the directory path via `MODEL_DIR` and ensure it exists on import
- add regression test to verify the directory alignment with the script location

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd731b1848332bc36320b45feb846